### PR TITLE
Update scorecards-analysis workflow to utilize `GITHUB_TOKEN` instead of PAT

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -31,17 +31,13 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@e363bfca00e752f91de7b7d2a77340e2e523cb18
+        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
         with:
           results_file: results.sarif
           results_format: sarif
-          # Read-only PAT token. To create it,
-          # follow the steps in https://github.com/ossf/scorecard-action#pat-token-creation.
-          repo_token: ${{ secrets.SCORECARD_READ_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           # Publish the results to enable scorecard badges. For more details, see
-          # https://github.com/ossf/scorecard-action#publishing-results.
-          # For private repositories, `publish_results` will automatically be set to `false`,
-          # regardless of the value entered here.
+          # https://github.com/ossf/scorecard-action#publishing-results
           publish_results: true
 
       # Upload the results as artifacts (optional).


### PR DESCRIPTION
The currently recommended approach for using the `ossf/scorecard-action` is to use the Actions `GITHUB_TOKEN` instead of a custom Personal Access Token:

https://github.com/ossf/scorecard-action?tab=readme-ov-file#authentication-with-fine-grained-pat-optional

This can also be seen in the related example workflow that OSSF provides:

https://github.com/ossf/scorecard/blob/62aca9907cbc960f45bc698bdf8c98c6bb76c2c0/.github/workflows/scorecard-analysis.yml

:warning: Furthermore: the read-only PAT that is currently being used by this workflow is owned by me. Since I am no longer a collaborator, I no longer wish to maintain this PAT after it expires. As such, please try to verify and merge this PR within the next week.