### PR TITLE
Adiciona testes  e mocks de verificação de endereço e casos extremos

### DIFF
--- a/server/__mocks__/addresses.js
+++ b/server/__mocks__/addresses.js
@@ -1,0 +1,142 @@
+const addresses = [
+    {
+        id: 1,
+        street: '123 Satellite Blvd',
+        city: 'Space City',
+        state: 'TX',
+        zip: '12345',
+        type: 'satellite'
+    },
+    {
+        id: 2,
+        street: '456 Non-Residential Rd',
+        city: 'Business Town',
+        state: 'CA',
+        zip: '67890',
+        type: 'non-residential'
+    },
+    {
+        id: 3,
+        street: '789 PO Box',
+        city: 'Mailville',
+        state: 'NY',
+        zip: '10112',
+        type: 'PO Box'
+    }
+];
+
+// Edge cases for address verification tests
+const addressEdgeCases = [
+  {
+    type: 'residential_house',
+    input: { line1: 'residential house', zip: '11111' },
+    expected: {
+      deliverable: true,
+      warning: null,
+      revisedAddress: {
+        line1: '1709 BRODERICK ST',
+        line2: null,
+        city: 'SAN FRANCISCO',
+        state: 'CA',
+        zip: '94115-2525'
+      }
+    }
+  },
+  {
+    type: 'residential_highrise',
+    input: { line1: 'residential highrise', zip: '11111' },
+    expected: {
+      deliverable: true,
+      revisedAddress: {
+        city: 'SAN FRANCISCO',
+        line1: '660 KING ST UNIT 305',
+        line2: null,
+        state: 'CA',
+        zip: '94107-1539'
+      },
+      warning: null
+    }
+  },
+  {
+    type: 'department_of_state',
+    input: { line1: 'department of state', zip: '11111' },
+    expected: {
+      deliverable: true,
+      revisedAddress: {
+        city: 'DPO',
+        line1: 'UNIT 8900 BOX 4301',
+        line2: null,
+        state: 'AE',
+        zip: '09831-4301'
+      },
+      warning: null
+    }
+  },
+  {
+    type: 'military',
+    input: { line1: 'military', zip: '11111' },
+    expected: {
+      deliverable: true,
+      revisedAddress: {
+        city: 'APO',
+        line1: 'CMR 409 BOX 145',
+        line2: null,
+        state: 'AE',
+        zip: '09053-0002'
+      },
+      warning: null
+    }
+  },
+  {
+    type: 'unnecessary_unit',
+    input: { line1: 'unnecessary unit', zip: '11111' },
+    expected: {
+      deliverable: true,
+      revisedAddress: {
+        city: 'SAN FRANCISCO',
+        line1: '1709 BRODERICK ST APT 505',
+        line2: null,
+        state: 'CA',
+        zip: '94115-2525'
+      },
+      warning: 'Address may be deliverable but contains an unnecessary suite number'
+    }
+  },
+  {
+    type: 'po_box',
+    input: { line1: 'po box', zip: '11111' },
+    expected: {
+      error: 'Post office boxes are not currently supported'
+    }
+  },
+  {
+    type: 'puerto_rico',
+    input: { line1: 'puerto rico', zip: '11111' },
+    expected: {
+      error: 'Puerto Rico addresses are not currently supported'
+    }
+  },
+  {
+    type: 'commercial_building',
+    input: { line1: 'deliverable', zip: '11111' },
+    expected: {
+      error: 'Non-residential addresses are not currently supported'
+    }
+  },
+  {
+    type: 'commercial_highrise',
+    input: { line1: 'commercial highrise', zip: '11111' },
+    expected: {
+      error: 'Non-residential addresses are not currently supported'
+    }
+  },
+  {
+    type: 'undeliverable',
+    input: { line1: 'undeliverable block match', zip: '11111' },
+    expected: {
+      error: 'Address is undeliverable'
+    }
+  }
+];
+
+module.exports = { addresses, addressEdgeCases };

--- a/server/__tests__/integration/lob.test.js
+++ b/server/__tests__/integration/lob.test.js
@@ -3,6 +3,7 @@ const request = require('supertest')
 const axios = require('axios')
 const express = require('express')
 const apiRouter = require('../../api')
+const { addresses, addressEdgeCases } = require('../../__mocks__/addresses')
 
 // Create a test application
 const app = express()
@@ -505,6 +506,33 @@ describe('POST /api/lob/createLetter', () => {
     // The expected object includes an expected_delivery_date property of any string
     expect(response.body).toEqual({
       expected_delivery_date: expect.any(String)
+    })
+  })
+})
+
+describe('POST /api/lob/addressVerification edge cases', () => {
+  const route = '/api/lob/addressVerification'
+
+  // Test using addressEdgeCases
+  addressEdgeCases.forEach(({ type, input, expected }) => {
+    test(`handles edge case: ${type}`, async () => {
+      const response = await request(app).post(route).send(input)
+      if (expected.error) {
+        expect(response.status).toBe(400)
+        expect(response.body).toEqual(expected)
+      } else {
+        expect(response.status).toBe(200)
+        expect(response.body).toEqual(expected)
+      }
+    })
+  })
+
+  // Test using addresses (basic structure, can be expanded as needed)
+  addresses.forEach(({  street, zip, type }) => {
+    test(`handles mock address: ${type}`, async () => {
+      const response = await request(app).post(route).send({ line1: street, zip })
+      // Como addresses não tem expected, apenas verifica se retorna algum status (ajuste conforme necessário)
+      expect([200, 400]).toContain(response.status)
     })
   })
 })


### PR DESCRIPTION
This PR improves the test coverage for the Lob address verification API by introducing structured mock data and dynamic tests for both standard and edge case addresses.
Key Changes:

Created a mock model file ([addresses.js](https://jubilant-space-couscous-j4xgg6g945rcp4jx.github.dev/)) containing two arrays:
[addresses](https://jubilant-space-couscous-j4xgg6g945rcp4jx.github.dev/): standard mock addresses for general testing.
[addressEdgeCases](https://jubilant-space-couscous-j4xgg6g945rcp4jx.github.dev/): a comprehensive set of edge case addresses (e.g., satellites, non-residential, P.O. boxes, military, Puerto Rico, etc.) with expected results.
Updated the integration test ([lob.test.js](https://jubilant-space-couscous-j4xgg6g945rcp4jx.github.dev/)):
Imports both [addresses](https://jubilant-space-couscous-j4xgg6g945rcp4jx.github.dev/) and [addressEdgeCases](https://jubilant-space-couscous-j4xgg6g945rcp4jx.github.dev/) from the mock file.
Adds a new test suite that dynamically iterates over [addressEdgeCases](https://jubilant-space-couscous-j4xgg6g945rcp4jx.github.dev/), asserting the API response matches the expected result for each edge case.
Adds a dynamic test for the basic [addresses](https://jubilant-space-couscous-j4xgg6g945rcp4jx.github.dev/) array to ensure all mock addresses are handled by the endpoint.
Ensures maintainability and scalability by centralizing mock data and making it easy to add new cases in the future.
Motivation:
This change ensures that all relevant address scenarios, including edge cases, are consistently tested. It also makes the test code cleaner and easier to extend as new requirements or edge cases arise.

How to test:
Run the test suite with [npm test](https://jubilant-space-couscous-j4xgg6g945rcp4jx.github.dev/) or [npx jest](https://jubilant-space-couscous-j4xgg6g945rcp4jx.github.dev/) and verify that all address verification scenarios pass as expected.