### PR TITLE
Potential fix for code scanning alert no. 20: Use of externally-controlled format string

### DIFF
--- a/server/routes/api/checkout.js
+++ b/server/routes/api/checkout.js
@@ -190,7 +190,7 @@ router.post('/process-transaction', async (req, res) => {
     const { id: paymentIntent, amount } = data.object
     const [eventType, eventOutcome] = req.body.type.split('.')
 
-    console.log(paymentIntent, amount, eventOutcome)
+    console.log('%s %s %s', paymentIntent, amount, eventOutcome)
 
     // We are not going to send letters from here just yet
     // so we will record the transaction no matter the outcome.


### PR DESCRIPTION
Potential fix for [https://github.com/OpenSourceFellows/amplify/security/code-scanning/20](https://github.com/OpenSourceFellows/amplify/security/code-scanning/20)

To fix this issue, we should ensure that untrusted user input is never used as a format string in a logging or formatting function. The best and most reliable way to do this in Node.js is to provide a constant format string with `%s` placeholders, and pass all untrusted data as arguments to be interpolated. This way, even if the user supplies malicious format specifiers, they will be treated as plain strings and not interpreted. Specifically, in `console.log(paymentIntent, amount, eventOutcome)`, we should change this to `console.log('%s %s %s', paymentIntent, amount, eventOutcome)`. No new imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
